### PR TITLE
增加卸载的目录

### DIFF
--- a/assets/entrypoint
+++ b/assets/entrypoint
@@ -24,6 +24,8 @@ def mount_points():
         mtab = line.split()
         if len(mtab) > 1 and mtab[4].startswith(base + '/') and mtab[4].endswith('shm') and 'containers' in mtab[4]:
             points.add(mtab[4])
+        if len(mtab) > 1 and mtab[4].startswith(base + '/') and 'kubernetes.io~secret' in mtab[4]:
+            points.add(mtab[4])
     return points
 
 


### PR DESCRIPTION
log-pilot 运行在 Kubernetes 环境中时, 该 pod 会挂载其他 pod default-token目录, 导致节点被驱逐时, 其他 pod 由于 default-token 目录被 log-pilot 挂载而导致的 device busy 报错. 此更新通过增加卸载的目录列表来解决这个问题