### PR TITLE
feat: add container env prefix COM_ALIYUN_META_ENVS_ as custom metas.

### DIFF
--- a/pilot/extension.go
+++ b/pilot/extension.go
@@ -1,8 +1,9 @@
 package pilot
 
 import (
-	"github.com/docker/docker/api/types"
 	"strings"
+
+	"github.com/docker/docker/api/types"
 )
 
 func extension(container map[string]string, containerJSON *types.ContainerJSON) {
@@ -12,6 +13,25 @@ func extension(container map[string]string, containerJSON *types.ContainerJSON) 
 			//fmt.Printf("label: %s=%s\n", name, value)
 			name = strings.Replace(name, ".", "_", -1)
 			putIfNotEmpty(container, name, value)
+		}
+	}
+	env := containerJSON.Config.Env
+	containerEnvMap := make(map[string]string)     // all container envs map
+	containerMetaEnvMap := make(map[string]string) // container meta env which will be injected into log-pilot
+	for _, e := range env {
+		envKV := strings.SplitN(e, "=", 2)
+		containerEnvMap[envKV[0]] = envKV[1]
+		if strings.HasPrefix(e, "COM_ALIYUN_META_ENVS_") {
+			// e.g. COM_ALIYUN_META_ENVS_MY_POD_IP = k8s_pod_ip
+			// MY_POD_IP is the original env key,
+			// k8s_pod_ip is the target field name which put into the tplt.
+			metaEnvName := strings.TrimPrefix(envKV[0], "COM_ALIYUN_META_ENVS_")
+			containerMetaEnvMap[metaEnvName] = envKV[1]
+		}
+	}
+	for metaEnvKey, metaEnvValueAsFieldName := range containerMetaEnvMap {
+		if envValue, exists := containerEnvMap[metaEnvKey]; exists {
+			putIfNotEmpty(container, metaEnvValueAsFieldName, envValue)
 		}
 	}
 }


### PR DESCRIPTION
As the PR title said, this PR is going to add a handler for container envs which has prefix with `COM_ALIYUN_META_ENVS_`, those envs will be processed, and the name which trimmed the prefix would be the actual env name from docker container spec, and the value will be log-pilot `container` field name.

Since these envs are defined as container metas, I set the magic prefix name to `COM_ALIYUN_META_ENVS_`, it fixed #274 .

Thanks.
